### PR TITLE
Use parent context for <Provider> in React 0.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "mocha-jsdom": "~0.4.0",
     "react": "^0.14.0-beta3",
     "react-addons-test-utils": "^0.14.0-beta3",
-    "react-dom": "^0.14.0-beta3",
     "redux": "^1.0.1",
     "rimraf": "^2.3.4",
     "webpack": "^1.11.0"

--- a/test/components/Provider.spec.js
+++ b/test/components/Provider.spec.js
@@ -4,6 +4,7 @@ import React, { PropTypes, Component } from 'react';
 import TestUtils from 'react-addons-test-utils';
 import { createStore } from 'redux';
 import { Provider } from '../../src/index';
+import createProvider from '../../src/components/createProvider';
 
 describe('React', () => {
   describe('Provider', () => {
@@ -19,14 +20,152 @@ describe('React', () => {
       }
     }
 
+    it('should not warn when using child-as-a-function before React 0.14', () => {
+      const store = createStore(() => ({}));
+      ['0.13.0-beta', '0.13.0', '0.13.3'].forEach(version => {
+        const LocalProvider = createProvider({ ...React, version });
+
+        let spy = expect.spyOn(console, 'error');
+        const tree = TestUtils.renderIntoDocument(
+          <LocalProvider store={store}>
+            {() => <Child />}
+          </LocalProvider>
+        );
+        spy.destroy();
+        expect(spy.calls.length).toBe(0);
+
+        spy = expect.spyOn(console, 'error');
+        tree.forceUpdate();
+        spy.destroy();
+        expect(spy.calls.length).toBe(0);
+      });
+    });
+
+    it('should warn once when using a single element before React 0.14', () => {
+      const store = createStore(() => ({}));
+      ['0.13.0-beta', '0.13.0', '0.13.3'].forEach(version => {
+        const LocalProvider = createProvider({ ...React, version });
+        // Trick React into checking propTypes every time:
+        LocalProvider.displayName = Math.random().toString();
+
+        let spy = expect.spyOn(console, 'error');
+        const tree = TestUtils.renderIntoDocument(
+          <LocalProvider store={store}>
+            <Child />
+          </LocalProvider>
+        );
+        spy.destroy();
+
+        expect(spy.calls.length).toBe(2);
+        expect(spy.calls[0].arguments[0]).toMatch(
+          /Invalid prop `children` of type `object` supplied to .*, expected `function`./
+        );
+        expect(spy.calls[1].arguments[0]).toMatch(
+          /With React 0.13, you need to wrap <Provider> child into a function. This restriction will be removed with React 0.14./
+        );
+
+        spy = expect.spyOn(console, 'error');
+        tree.forceUpdate();
+        spy.destroy();
+        expect(spy.calls.length).toBe(0);
+      });
+    });
+
+    it('should warn once when using child-as-a-function after React 0.14', () => {
+      const store = createStore(() => ({}));
+      ['0.14.0-beta3', '0.14.0', '0.14.2', '0.15.0-beta', '1.0.0-beta', '1.0.0'].forEach(version => {
+        const LocalProvider = createProvider({ ...React, version });
+        // Trick React into checking propTypes every time:
+        LocalProvider.displayName = Math.random().toString();
+
+        let spy = expect.spyOn(console, 'error');
+        const tree = TestUtils.renderIntoDocument(
+          <LocalProvider store={store}>
+            {() => <Child />}
+          </LocalProvider>
+        );
+        spy.destroy();
+
+        expect(spy.calls.length).toBe(2);
+        expect(spy.calls[0].arguments[0]).toMatch(
+          /Invalid prop `children` supplied to .*, expected a single ReactElement./
+        );
+        expect(spy.calls[1].arguments[0]).toMatch(
+          /With React 0.14 and later versions, you no longer need to wrap <Provider> child into a function./
+        );
+
+        spy = expect.spyOn(console, 'error');
+        tree.forceUpdate();
+        spy.destroy();
+        expect(spy.calls.length).toBe(0);
+      });
+    });
+
+    it('should enforce a single child', () => {
+      const store = createStore(() => ({}));
+
+      expect(() => TestUtils.renderIntoDocument(
+        <Provider store={store}>
+          <div />
+        </Provider>
+      )).toNotThrow();
+
+      expect(() => TestUtils.renderIntoDocument(
+        <Provider store={store}>
+        </Provider>
+      )).toThrow(/exactly one child/);
+
+      expect(() => TestUtils.renderIntoDocument(
+        <Provider store={store}>
+          <div />
+          <div />
+        </Provider>
+      )).toThrow(/exactly one child/);
+    });
+
+    it('should enforce a single child when using function-as-a-child', () => {
+      const store = createStore(() => ({}));
+
+      expect(() => TestUtils.renderIntoDocument(
+        <Provider store={store}>
+          {() => <div />}
+        </Provider>
+      )).toNotThrow();
+
+      expect(() => TestUtils.renderIntoDocument(
+        <Provider store={store}>
+          {() => {}}
+        </Provider>
+      )).toThrow(/exactly one child/);
+    });
+
     it('should add the store to the child context', () => {
       const store = createStore(() => ({}));
 
+      const spy = expect.spyOn(console, 'error');
+      const tree = TestUtils.renderIntoDocument(
+        <Provider store={store}>
+          <Child />
+        </Provider>
+      );
+      spy.destroy();
+      expect(spy.calls.length).toBe(0);
+
+      const child = TestUtils.findRenderedComponentWithType(tree, Child);
+      expect(child.context.store).toBe(store);
+    });
+
+    it('should add the store to the child context with function-as-a-child', () => {
+      const store = createStore(() => ({}));
+
+      const spy = expect.spyOn(console, 'error');
       const tree = TestUtils.renderIntoDocument(
         <Provider store={store}>
           {() => <Child />}
         </Provider>
       );
+      spy.destroy();
+      expect(spy.calls.length).toBe(0);
 
       const child = TestUtils.findRenderedComponentWithType(tree, Child);
       expect(child.context.store).toBe(store);
@@ -43,7 +182,7 @@ describe('React', () => {
         render() {
           return (
             <Provider store={this.state.store}>
-              {() => <Child />}
+              <Child />
             </Provider>
           );
         }

--- a/test/components/connect.spec.js
+++ b/test/components/connect.spec.js
@@ -1,6 +1,6 @@
 import expect from 'expect';
 import jsdom from 'mocha-jsdom';
-import React, { createClass, PropTypes, Component } from 'react';
+import React, { createClass, Children, PropTypes, Component } from 'react';
 import TestUtils from 'react-addons-test-utils';
 import { createStore } from 'redux';
 import { connect } from '../../src/index';
@@ -25,7 +25,7 @@ describe('React', () => {
       }
 
       render() {
-        return this.props.children();
+        return Children.only(this.props.children);
       }
     }
 
@@ -47,9 +47,7 @@ describe('React', () => {
 
       const tree = TestUtils.renderIntoDocument(
         <ProviderMock store={store}>
-          {() => (
-            <Container pass="through" />
-          )}
+          <Container pass="through" />
         </ProviderMock>
       );
 
@@ -73,7 +71,7 @@ describe('React', () => {
 
       const container = TestUtils.renderIntoDocument(
         <ProviderMock store={store}>
-          {() => <Container pass='through' baz={50} />}
+          <Container pass='through' baz={50} />
         </ProviderMock>
       );
       const stub = TestUtils.findRenderedComponentWithType(container, Passthrough);
@@ -98,9 +96,7 @@ describe('React', () => {
 
       const tree = TestUtils.renderIntoDocument(
         <ProviderMock store={store}>
-          {() => (
-            <Container />
-          )}
+          <Container />
         </ProviderMock>
       );
 
@@ -128,9 +124,7 @@ describe('React', () => {
 
       const tree = TestUtils.renderIntoDocument(
         <ProviderMock store={store}>
-          {() => (
-            <Container />
-          )}
+          <Container />
         </ProviderMock>
       );
 
@@ -171,7 +165,7 @@ describe('React', () => {
         render() {
           return (
             <ProviderMock store={store}>
-              {() => <ConnectContainer bar={this.state.bar} />}
+              <ConnectContainer bar={this.state.bar} />
              </ProviderMock>
           );
         }
@@ -207,9 +201,7 @@ describe('React', () => {
 
       TestUtils.renderIntoDocument(
         <ProviderMock store={store}>
-          {() => (
-            <HolderContainer ref={instance => container = instance} />
-          )}
+          <HolderContainer ref={instance => container = instance} />
         </ProviderMock>
       );
 
@@ -252,9 +244,7 @@ describe('React', () => {
 
       TestUtils.renderIntoDocument(
         <ProviderMock store={store}>
-          {() => (
-            <HolderContainer ref={instance => container = instance} />
-          )}
+          <HolderContainer ref={instance => container = instance} />
         </ProviderMock>
       );
 
@@ -308,7 +298,7 @@ describe('React', () => {
         render() {
           return (
             <ProviderMock store={store}>
-              {() => <ConnectContainer bar={this.state.bar} />}
+              <ConnectContainer bar={this.state.bar} />
              </ProviderMock>
           );
         }
@@ -359,7 +349,7 @@ describe('React', () => {
         render() {
           return (
             <ProviderMock store={store}>
-              {() => <Container extra={this.state.extra} />}
+              <Container extra={this.state.extra} />
             </ProviderMock>
           );
         }
@@ -394,7 +384,7 @@ describe('React', () => {
 
       const container = TestUtils.renderIntoDocument(
         <ProviderMock store={store}>
-          {() => <Container pass='through' />}
+          <Container pass='through' />
         </ProviderMock>
       );
       const stub = TestUtils.findRenderedComponentWithType(container, Passthrough);
@@ -441,16 +431,14 @@ describe('React', () => {
         }
       }
 
-      const tree = TestUtils.renderIntoDocument(
+      let outerComponent;
+      TestUtils.renderIntoDocument(
         <ProviderMock store={store}>
-          {() => (
-            <OuterComponent ref='outerComponent' />
-          )}
+          <OuterComponent ref={c => outerComponent = c} />
         </ProviderMock>
       );
-
-      tree.refs.outerComponent.setFoo('BAR');
-      tree.refs.outerComponent.setFoo('DID');
+      outerComponent.setFoo('BAR');
+      outerComponent.setFoo('DID');
 
       expect(invocationCount).toEqual(2);
     });
@@ -491,16 +479,15 @@ describe('React', () => {
         }
       }
 
-      const tree = TestUtils.renderIntoDocument(
+      let outerComponent;
+      TestUtils.renderIntoDocument(
         <ProviderMock store={store}>
-          {() => (
-            <OuterComponent ref='outerComponent' />
-          )}
+          <OuterComponent ref={c => outerComponent = c} />
         </ProviderMock>
       );
 
-      tree.refs.outerComponent.setFoo('BAR');
-      tree.refs.outerComponent.setFoo('BAZ');
+      outerComponent.setFoo('BAR');
+      outerComponent.setFoo('BAZ');
 
       expect(invocationCount).toEqual(4);
       expect(propsPassedIn).toEqual({
@@ -542,16 +529,15 @@ describe('React', () => {
         }
       }
 
-      const tree = TestUtils.renderIntoDocument(
+      let outerComponent;
+      TestUtils.renderIntoDocument(
         <ProviderMock store={store}>
-          {() => (
-            <OuterComponent ref='outerComponent' />
-          )}
+          <OuterComponent ref={c => outerComponent = c} />
         </ProviderMock>
       );
 
-      tree.refs.outerComponent.setFoo('BAR');
-      tree.refs.outerComponent.setFoo('DID');
+      outerComponent.setFoo('BAR');
+      outerComponent.setFoo('DID');
 
       expect(invocationCount).toEqual(1);
     });
@@ -592,16 +578,15 @@ describe('React', () => {
         }
       }
 
-      const tree = TestUtils.renderIntoDocument(
+      let outerComponent;
+      TestUtils.renderIntoDocument(
         <ProviderMock store={store}>
-          {() => (
-            <OuterComponent ref='outerComponent' />
-          )}
+          <OuterComponent ref={c => outerComponent = c} />
         </ProviderMock>
       );
 
-      tree.refs.outerComponent.setFoo('BAR');
-      tree.refs.outerComponent.setFoo('BAZ');
+      outerComponent.setFoo('BAR');
+      outerComponent.setFoo('BAZ');
 
       expect(invocationCount).toEqual(3);
       expect(propsPassedIn).toEqual({
@@ -624,7 +609,7 @@ describe('React', () => {
 
         const container = TestUtils.renderIntoDocument(
           <ProviderMock store={store}>
-            {() => <Container pass='through' />}
+            <Container pass='through' />
           </ProviderMock>
         );
         const stub = TestUtils.findRenderedComponentWithType(container, Passthrough);
@@ -669,9 +654,7 @@ describe('React', () => {
 
       const tree = TestUtils.renderIntoDocument(
         <ProviderMock store={store}>
-          {() => (
-            <Container />
-          )}
+          <Container />
         </ProviderMock>
       );
 
@@ -701,9 +684,7 @@ describe('React', () => {
 
       const tree = TestUtils.renderIntoDocument(
         <ProviderMock store={store}>
-          {() => (
-            <Container />
-          )}
+          <Container />
         </ProviderMock>
       );
 
@@ -750,9 +731,7 @@ describe('React', () => {
         render() {
           return (
             <ProviderMock store={store}>
-              {() => (
-                <Container pass={this.state.pass} />
-              )}
+              <Container pass={this.state.pass} />
             </ProviderMock>
           );
         }
@@ -827,7 +806,7 @@ describe('React', () => {
       expect(() => {
         TestUtils.renderIntoDocument(
           <ProviderMock store={store}>
-            { () => makeContainer(() => 1, () => ({}), () => ({})) }
+            {makeContainer(() => 1, () => ({}), () => ({}))}
           </ProviderMock>
         );
       }).toThrow(/mapState/);
@@ -835,7 +814,7 @@ describe('React', () => {
       expect(() => {
         TestUtils.renderIntoDocument(
           <ProviderMock store={store}>
-            { () => makeContainer(() => 'hey', () => ({}), () => ({})) }
+            {makeContainer(() => 'hey', () => ({}), () => ({}))}
           </ProviderMock>
         );
       }).toThrow(/mapState/);
@@ -843,7 +822,7 @@ describe('React', () => {
       expect(() => {
         TestUtils.renderIntoDocument(
           <ProviderMock store={store}>
-            { () => makeContainer(() => new AwesomeMap(), () => ({}), () => ({})) }
+            {makeContainer(() => new AwesomeMap(), () => ({}), () => ({}))}
           </ProviderMock>
         );
       }).toThrow(/mapState/);
@@ -851,7 +830,7 @@ describe('React', () => {
       expect(() => {
         TestUtils.renderIntoDocument(
           <ProviderMock store={store}>
-            { () => makeContainer(() => ({}), () => 1, () => ({})) }
+            {makeContainer(() => ({}), () => 1, () => ({}))}
           </ProviderMock>
         );
       }).toThrow(/mapDispatch/);
@@ -859,7 +838,7 @@ describe('React', () => {
       expect(() => {
         TestUtils.renderIntoDocument(
           <ProviderMock store={store}>
-            { () => makeContainer(() => ({}), () => 'hey', () => ({})) }
+            {makeContainer(() => ({}), () => 'hey', () => ({}))}
           </ProviderMock>
         );
       }).toThrow(/mapDispatch/);
@@ -867,7 +846,7 @@ describe('React', () => {
       expect(() => {
         TestUtils.renderIntoDocument(
           <ProviderMock store={store}>
-            { () => makeContainer(() => ({}), () => new AwesomeMap(), () => ({})) }
+            {makeContainer(() => ({}), () => new AwesomeMap(), () => ({}))}
           </ProviderMock>
         );
       }).toThrow(/mapDispatch/);
@@ -875,7 +854,7 @@ describe('React', () => {
       expect(() => {
         TestUtils.renderIntoDocument(
           <ProviderMock store={store}>
-            { () => makeContainer(() => ({}), () => ({}), () => 1) }
+            {makeContainer(() => ({}), () => ({}), () => 1)}
           </ProviderMock>
         );
       }).toThrow(/mergeProps/);
@@ -883,7 +862,7 @@ describe('React', () => {
       expect(() => {
         TestUtils.renderIntoDocument(
           <ProviderMock store={store}>
-            { () => makeContainer(() => ({}), () => ({}), () => 'hey') }
+            {makeContainer(() => ({}), () => ({}), () => 'hey')}
           </ProviderMock>
         );
       }).toThrow(/mergeProps/);
@@ -891,7 +870,7 @@ describe('React', () => {
       expect(() => {
         TestUtils.renderIntoDocument(
           <ProviderMock store={store}>
-            { () => makeContainer(() => ({}), () => ({}), () => new AwesomeMap()) }
+            {makeContainer(() => ({}), () => ({}), () => new AwesomeMap())}
           </ProviderMock>
         );
       }).toThrow(/mergeProps/);
@@ -939,8 +918,8 @@ describe('React', () => {
       let container;
       TestUtils.renderIntoDocument(
         <ProviderMock store={store}>
-          {() => <ContainerBefore ref={instance => container = instance} />}
-         </ProviderMock>
+          <ContainerBefore ref={instance => container = instance} />
+        </ProviderMock>
       );
       const stub = TestUtils.findRenderedComponentWithType(container, Passthrough);
       expect(stub.props.foo).toEqual(undefined);
@@ -1075,9 +1054,7 @@ describe('React', () => {
 
       const tree = TestUtils.renderIntoDocument(
         <ProviderMock store={store}>
-          {() => (
-            <Decorated />
-          )}
+          <Decorated />
         </ProviderMock>
       );
 


### PR DESCRIPTION
This implements https://github.com/rackt/react-redux/issues/64 in a backward-compatible by checking `React.version`. Because I updated the tests to use 0.14 beta, I also manually ran the new source against the previous test suite, and it passed.

There's a single breaking change here: `<Provider>{() => {})</Provider>` will no longer work, as a single child (either as a function child or a vanilla child) is enforced.

When you try to use function as a child in 0.14, a warning is printed to the console. Conversely, React Redux warns you if you use a vanilla element in 0.13 where function as a child is needed.