### PR TITLE
Improve handling of React Native version warnings

### DIFF
--- a/src/components/createProvider.js
+++ b/src/components/createProvider.js
@@ -3,7 +3,7 @@ import createStoreShape from '../utils/createStoreShape';
 function isUsingOwnerContext(React) {
   const { version } = React;
   if (typeof version !== 'string') {
-    return false;
+    return true;
   }
 
   const sections = version.split('.');


### PR DESCRIPTION
Using React Native, a disruptive error appears to warn about function/no-function for Provider in app root.  It seems that the version check is failing as React.version is undefined in my React Native environment.  

As these are just warnings, perhaps it's best to use console.warn rather than console.error?  Or perhaps there is a better way to fix the version check?  

{
    "react": "^0.13.3",
    "react-native": "^0.8.0",
    "react-redux": "^1.0.0",
    "redux": "^1.0.1",
    "redux-thunk": "^0.1.0"
}
![ios simulator screen shot aug 25 2015 11 52 03 am](https://cloud.githubusercontent.com/assets/2029383/9471730/b7f567d0-4b1f-11e5-9d47-cae1850b6ab7.png)
