### PR TITLE
Remove support for changing store on the fly

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "mocha-jsdom": "~0.4.0",
     "react": "^0.14.0-beta3",
     "react-addons-test-utils": "^0.14.0-beta3",
-    "redux": "^1.0.1",
+    "redux": "^2.0.0",
     "rimraf": "^2.3.4",
     "webpack": "^1.11.0"
   },
@@ -60,6 +60,6 @@
     "invariant": "^2.0.0"
   },
   "peerDependencies": {
-    "redux": "^1.0.0 || 1.0.0-rc"
+    "redux": "^2.0.0"
   }
 }

--- a/src/components/createProvider.js
+++ b/src/components/createProvider.js
@@ -18,28 +18,44 @@ export default function createProvider(React) {
   const storeShape = createStoreShape(PropTypes);
   const requireFunctionChild = isUsingOwnerContext(React);
 
-  let didWarn = false;
-  function warnAboutFunction() {
-    if (didWarn || requireFunctionChild) {
+  let didWarnAboutChild = false;
+  function warnAboutFunctionChild() {
+    if (didWarnAboutChild || requireFunctionChild) {
       return;
     }
 
-    didWarn = true;
+    didWarnAboutChild = true;
     console.error( // eslint-disable-line no-console
       'With React 0.14 and later versions, you no longer need to ' +
       'wrap <Provider> child into a function.'
     );
   }
-  function warnAboutElement() {
-    if (didWarn || !requireFunctionChild) {
+  function warnAboutElementChild() {
+    if (didWarnAboutChild || !requireFunctionChild) {
       return;
     }
 
-    didWarn = true;
+    didWarnAboutChild = true;
     console.error( // eslint-disable-line no-console
       'With React 0.13, you need to ' +
       'wrap <Provider> child into a function. ' +
       'This restriction will be removed with React 0.14.'
+    );
+  }
+
+  let didWarnAboutReceivingStore = false;
+  function warnAboutReceivingStore() {
+    if (didWarnAboutReceivingStore) {
+      return;
+    }
+
+    didWarnAboutReceivingStore = true;
+    console.error( // eslint-disable-line no-console
+      '<Provider> does not support changing `store` on the fly. ' +
+      'It is most likely that you see this error because you updated to ' +
+      'Redux 2.x and React Redux 2.x which no longer hot reload reducers ' +
+      'automatically. See https://github.com/rackt/react-redux/releases/' +
+      'tag/v2.0.0 for the migration instructions.'
     );
   }
 
@@ -57,21 +73,20 @@ export default function createProvider(React) {
     };
 
     getChildContext() {
-      return { store: this.state.store };
+      return { store: this.store };
     }
 
     constructor(props, context) {
       super(props, context);
-      this.state = { store: props.store };
+      this.store = props.store;
     }
 
     componentWillReceiveProps(nextProps) {
-      const { store } = this.state;
+      const { store } = this;
       const { store: nextStore } = nextProps;
 
       if (store !== nextStore) {
-        const nextReducer = nextStore.getReducer();
-        store.replaceReducer(nextReducer);
+        warnAboutReceivingStore();
       }
     }
 
@@ -79,10 +94,10 @@ export default function createProvider(React) {
       let { children } = this.props;
 
       if (typeof children === 'function') {
-        warnAboutFunction();
+        warnAboutFunctionChild();
         children = children();
       } else {
-        warnAboutElement();
+        warnAboutElementChild();
       }
 
       return Children.only(children);


### PR DESCRIPTION
This removes the magical reducer replacement in favor of explicit `replaceReducer()` call where you create your store. See https://github.com/rackt/redux/pull/667 for details.