### PR TITLE
Rely on process.env.NODE_ENV being polyfilled

### DIFF
--- a/src/components/createConnect.js
+++ b/src/components/createConnect.js
@@ -205,16 +205,7 @@ export default function createConnect(React) {
         }
       }
 
-      if ((
-        // Node-like CommonJS environments (Browserify, Webpack)
-        typeof process !== 'undefined' &&
-        typeof process.env !== 'undefined' &&
-        process.env.NODE_ENV !== 'production'
-       ) ||
-        // React Native
-        typeof __DEV__ !== 'undefined' &&
-        __DEV__ // eslint-disable-line no-undef
-      ) {
+      if (process.env.NODE_ENV !== 'production') {
         Connect.prototype.componentWillUpdate = function componentWillUpdate() {
           if (this.version === version) {
             return;


### PR DESCRIPTION
Since React Native 0.10 is out and polyfills `process.env.NODE_ENV`, we can now safely rely on it being there. If you're not ready to use RN 0.10, or are in a different environment, either use a browser build, or shim it yourself.