### PR TITLE
add state to mapDispatchToProps

### DIFF
--- a/src/components/createConnect.js
+++ b/src/components/createConnect.js
@@ -52,10 +52,10 @@ export default function createConnect(React) {
     }
 
     function computeDispatchProps(store, props) {
-      const { dispatch } = store;
+      const { dispatch, state } = store;
       const dispatchProps = shouldUpdateDispatchProps ?
-        finalMapDispatchToProps(dispatch, props) :
-        finalMapDispatchToProps(dispatch);
+        finalMapDispatchToProps(dispatch, state, props) :
+        finalMapDispatchToProps(dispatch, state);
 
       invariant(
         isPlainObject(dispatchProps),

--- a/src/components/createConnect.js
+++ b/src/components/createConnect.js
@@ -52,7 +52,8 @@ export default function createConnect(React) {
     }
 
     function computeDispatchProps(store, props) {
-      const { dispatch, state } = store;
+      const { dispatch } = store;
+      const state = store.getState();
       const dispatchProps = shouldUpdateDispatchProps ?
         finalMapDispatchToProps(dispatch, state, props) :
         finalMapDispatchToProps(dispatch, state);

--- a/test/components/connect.spec.js
+++ b/test/components/connect.spec.js
@@ -548,7 +548,7 @@ describe('React', () => {
       let propsPassedIn;
       let invocationCount = 0;
 
-      @connect(null, (dispatch, props) => {
+      @connect(null, (dispatch, state, props) => {
         invocationCount++;
         propsPassedIn = props;
         return {};


### PR DESCRIPTION
This PR is for discussion.
Recently I have found the need to have the state in mapDispatchToProps.

I have an actionCreator like this:

```js
const addFeature = (some, state) => {
  // do something with state
}

const someActionCreator = (myFunction) => (options) => {
  //
};
```

And I want to write
```js
const selectActions = (dispatch, state) => ({
  someActionCreator: bindActionCreator(actionCreator(addFeature(state.data1, state.data2), dispatch)
});
export default connect(selectState, selectActions)(MyComponent);
```


I know there are other options to inject `addFeature(state.data1, state.data2)` to `someActionCreator` but I would like to do it without `MyComponent` knowing about it and this looks like a nice solution.

Any reason why this is a bad idea? Is there a better way?