### PR TITLE
Don't set state if unmounted during dispatch

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "mocha-jsdom": "~0.4.0",
     "react": "^0.14.0-beta3",
     "react-addons-test-utils": "^0.14.0-beta3",
+    "react-dom": "^0.14.0-beta3",
     "redux": "^2.0.0",
     "rimraf": "^2.3.4",
     "webpack": "^1.11.0"

--- a/src/components/createConnect.js
+++ b/src/components/createConnect.js
@@ -189,6 +189,10 @@ export default function createConnect(React) {
         }
 
         handleChange() {
+          if (!this.unsubscribe) {
+            return;
+          }
+
           if (this.updateStateProps()) {
             this.updateState();
           }


### PR DESCRIPTION
Previously, if you unmount the component during the dispatch cycle, the component itself is still going to receive the next state, call `mapStateToProps`, and attempt to call `setState`. This resulted in a warning by React that we're setting state on an unmounted component.

With this change, we bail out from handling any state changes if we have unsubscribed. Fixes #92, #95. 