### PR TITLE
Fix issues with stale props

### DIFF
--- a/test/components/connect.spec.js
+++ b/test/components/connect.spec.js
@@ -1212,5 +1212,38 @@ describe('React', () => {
       // store.dispatch({ type: 'APPEND', body: 'd'});
       // expect(childMapStateInvokes).toBe(5);
     });
+
+    it('should not render the wrapped component when mapState does not produce change', () => {
+      const store = createStore(stringBuilder);
+      let renderCalls = 0;
+      let mapStateCalls = 0;
+
+      @connect(() => {
+        mapStateCalls++;
+        return {}; // no change!
+      })
+      class Container extends Component {
+        render() {
+          renderCalls++;
+          return <Passthrough {...this.props} />;
+        }
+      }
+
+      TestUtils.renderIntoDocument(
+        <ProviderMock store={store}>
+          <Container />
+        </ProviderMock>
+      );
+
+      expect(renderCalls).toBe(1);
+      expect(mapStateCalls).toBe(2);
+
+      store.dispatch({ type: 'APPEND', body: 'a'});
+
+      // After store a change mapState has been called
+      expect(mapStateCalls).toBe(3);
+      // But render is not because it did not make any actual changes
+      expect(renderCalls).toBe(1);
+    });
   });
 });

--- a/test/components/connect.spec.js
+++ b/test/components/connect.spec.js
@@ -1147,5 +1147,70 @@ describe('React', () => {
       wrapper.setState({ value: 1 });
       expect(target.props.statefulValue).toEqual(1);
     });
+
+    it('should pass state consistently to mapState', () => {
+      const store = createStore(stringBuilder);
+
+      store.dispatch({ type: 'APPEND', body: 'a'});
+      let childMapStateInvokes = 0;
+
+      @connect(state => ({ state }))
+      class Container extends Component {
+
+        emitChange() {
+          store.dispatch({ type: 'APPEND', body: 'b'});
+        }
+
+        render() {
+          return (
+            <div>
+              <button ref="button" onClick={this.emitChange.bind(this)}>change</button>
+              <ChildContainer parentState={this.props.state} />
+            </div>
+          );
+        }
+      }
+
+      @connect((state, parentProps) => {
+        childMapStateInvokes++;
+        // The state from parent props should always be consistent with the current state
+        expect(state).toEqual(parentProps.parentState);
+        return {};
+      })
+      class ChildContainer extends Component {
+        render() {
+          return <Passthrough {...this.props}/>;
+        }
+      }
+
+      const tree = TestUtils.renderIntoDocument(
+        <ProviderMock store={store}>
+          <Container />
+        </ProviderMock>
+      );
+
+      expect(childMapStateInvokes).toBe(2);
+
+      // The store state stays consistent when setState calls are batched
+      ReactDOM.unstable_batchedUpdates(() => {
+        store.dispatch({ type: 'APPEND', body: 'c'});
+      });
+      expect(childMapStateInvokes).toBe(3);
+
+      // setState calls DOM handlers are batched
+      const container = TestUtils.findRenderedComponentWithType(tree, Container);
+      const node = React.findDOMNode(container.getWrappedInstance().refs.button);
+      TestUtils.Simulate.click(node);
+      expect(childMapStateInvokes).toBe(4);
+
+      // In future all setState calls will be batched[1]. Uncomment when it
+      // happens. For now redux-batched-updates middleware can be used as
+      // workaround this.
+      //
+      // [1]: https://twitter.com/sebmarkbage/status/642366976824864768
+      //
+      // store.dispatch({ type: 'APPEND', body: 'd'});
+      // expect(childMapStateInvokes).toBe(5);
+    });
   });
 });


### PR DESCRIPTION
Fix for #86

The idea in this change is to delay executing `mapStateToProps` until the render call. The render call is forced for every state change by setting the store state to the component state for every connect wrapper. This works because state changes are batched in React. Which means that when the render and there for the `mapStateToProps` is executed the state and any props based on it are consistent across the full component tree. Which is awesome!

Only concern that I have with this is performance. That's why in the second commit I add a pure render wrapper component (`PureWrap`) which makes sure that the original component is only rendered when the `mapStateToProps` actually produces a change. Not sure whether this is better or worse than the original. But even if this is not that performant I'd prefer it because it avoids whole class of weird edge cases.

----

Anyone wanting to help and test this I pushed a compiled version to `epeli/react-redux#fix86`. Put that in your package.json as the `react-redux` version number.