### PR TITLE
Static methods using @connect

### DIFF
--- a/src/components/createConnect.js
+++ b/src/components/createConnect.js
@@ -76,7 +76,7 @@ export default function createConnect(React) {
     }
 
     return function wrapWithConnect(WrappedComponent) {
-      class Connect extends Component {
+      class Connect extends WrappedComponent {
         static displayName = `Connect(${getDisplayName(WrappedComponent)})`;
         static WrappedComponent = WrappedComponent;
 


### PR DESCRIPTION
This isn't currently possible:

```js
@connect()
class Foo {
  static bar () {
    return 'baz'
  }

  quux () {
    return Foo.bar() // doesn't work
  }
}
```

```js
// current behaviour
import WrappedFoo from './Foo'
WrappedFoo.WrappedComponent.bar() // 'baz'

// desired behaviour
import Foo from './Foo'
Foo.bar() // 'baz'
```

It's worth noting that there are potential side effects to this change. A given component might define lifecycle methods that aren't present on the connect component, thus altering its behaviour. Consider this by no means ready to go - just want to open up the discussion to explore a solution.