### PR TITLE
Allow connect() to hoist non-react statics from wrapped component

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "webpack": "^1.11.0"
   },
   "dependencies": {
+    "hoist-non-react-statics": "^1.0.3",
     "invariant": "^2.0.0"
   },
   "peerDependencies": {

--- a/src/components/createConnect.js
+++ b/src/components/createConnect.js
@@ -2,6 +2,7 @@ import createStoreShape from '../utils/createStoreShape';
 import shallowEqual from '../utils/shallowEqual';
 import isPlainObject from '../utils/isPlainObject';
 import wrapActionCreators from '../utils/wrapActionCreators';
+import hoistStatics from 'hoist-non-react-statics';
 import invariant from 'invariant';
 
 const defaultMapStateToProps = () => ({});
@@ -232,7 +233,7 @@ export default function createConnect(React) {
         };
       }
 
-      return Connect;
+      return hoistStatics(Connect, WrappedComponent);
     };
   };
 }

--- a/test/components/connect.spec.js
+++ b/test/components/connect.spec.js
@@ -1021,6 +1021,24 @@ describe('React', () => {
       expect(decorated.WrappedComponent).toBe(Container);
     });
 
+    it('should hoist non-react statics from wrapped component', () => {
+      class Container extends Component {
+        static howIsRedux = () => 'Awesome!';
+        static foo = 'bar';
+
+        render() {
+          return <Passthrough />;
+        }
+      }
+
+      const decorator = connect(state => state);
+      const decorated = decorator(Container);
+
+      expect(decorated.howIsRedux).toBeA('function');
+      expect(decorated.howIsRedux()).toBe('Awesome!');
+      expect(decorated.foo).toBe('bar');
+    });
+
     it('should use the store from the props instead of from the context if present', () => {
       class Container extends Component {
         render() {


### PR DESCRIPTION
* Adds dependency on [`hoist-non-react-statics`](https://github.com/mridgway/hoist-non-react-statics)
* Fixes #53