### PR TITLE
ie8 Support by alternative method for adding static properties

### DIFF
--- a/src/components/createConnect.js
+++ b/src/components/createConnect.js
@@ -206,7 +206,8 @@ export default function createConnect(React) {
           );
         }
       }
-      // to prevent breaking ie8 
+      //adding properties in this way
+      //prevents ie8 from breaking
       Connect.displayName = `Connect(${getDisplayName(WrappedComponent)})`;
       Connect.WrappedComponent = WrappedComponent;
 

--- a/src/components/createConnect.js
+++ b/src/components/createConnect.js
@@ -78,7 +78,6 @@ export default function createConnect(React) {
 
     return function wrapWithConnect(WrappedComponent) {
       class Connect extends Component {
-        
 
         shouldComponentUpdate(nextProps, nextState) {
           if (!pure) {
@@ -206,8 +205,8 @@ export default function createConnect(React) {
           );
         }
       }
-      //adding properties in this way
-      //prevents ie8 from breaking
+      // adding properties in this way
+      // prevents ie8 from breaking
       Connect.displayName = `Connect(${getDisplayName(WrappedComponent)})`;
       Connect.WrappedComponent = WrappedComponent;
 

--- a/src/components/createConnect.js
+++ b/src/components/createConnect.js
@@ -78,16 +78,7 @@ export default function createConnect(React) {
 
     return function wrapWithConnect(WrappedComponent) {
       class Connect extends Component {
-        static displayName = `Connect(${getDisplayName(WrappedComponent)})`;
-        static WrappedComponent = WrappedComponent;
-
-        static contextTypes = {
-          store: storeShape
-        };
-
-        static propTypes = {
-          store: storeShape
-        };
+        
 
         shouldComponentUpdate(nextProps, nextState) {
           if (!pure) {
@@ -215,6 +206,16 @@ export default function createConnect(React) {
           );
         }
       }
+      // to prevent breaking ie8 
+      Connect.displayName = `Connect(${getDisplayName(WrappedComponent)})`;
+      Connect.WrappedComponent = WrappedComponent;
+
+      Connect.contextTypes = {
+        store: storeShape
+      };
+      Connect.propTypes = {
+        store: storeShape
+      };
 
       if (process.env.NODE_ENV !== 'production') {
         Connect.prototype.componentWillUpdate = function componentWillUpdate() {

--- a/src/components/createProvider.js
+++ b/src/components/createProvider.js
@@ -59,18 +59,7 @@ export default function createProvider(React) {
     );
   }
 
-  return class Provider extends Component {
-    static childContextTypes = {
-      store: storeShape.isRequired
-    };
-
-    static propTypes = {
-      store: storeShape.isRequired,
-      children: (requireFunctionChild ?
-        PropTypes.func :
-        PropTypes.element
-      ).isRequired
-    };
+  class Provider extends Component {
 
     getChildContext() {
       return { store: this.store };
@@ -102,5 +91,17 @@ export default function createProvider(React) {
 
       return Children.only(children);
     }
+  }
+  Provider.childContextTypes = {
+    store: storeShape.isRequired
   };
+
+    Provider.propTypes = {
+    store: storeShape.isRequired,
+    children: (requireFunctionChild ?
+      PropTypes.func :
+      PropTypes.element
+    ).isRequired
+  };
+  return Provider;
 }

--- a/src/components/createProvider.js
+++ b/src/components/createProvider.js
@@ -92,8 +92,8 @@ export default function createProvider(React) {
       return Children.only(children);
     }
   }
-  //adding properties in this way
-  //prevents ie8 from breaking
+  // adding properties in this way
+  // prevents ie8 from breaking
   Provider.childContextTypes = {
     store: storeShape.isRequired
   };

--- a/src/components/createProvider.js
+++ b/src/components/createProvider.js
@@ -92,11 +92,13 @@ export default function createProvider(React) {
       return Children.only(children);
     }
   }
+  //adding properties in this way
+  //prevents ie8 from breaking
   Provider.childContextTypes = {
     store: storeShape.isRequired
   };
 
-    Provider.propTypes = {
+  Provider.propTypes = {
     store: storeShape.isRequired,
     children: (requireFunctionChild ?
       PropTypes.func :


### PR DESCRIPTION
I've successfully tested this in ie8!

It works with the help of [core-js](https://github.com/zloirock/core-js) and other, lesser shims failed me. But this passes all the tests and chrome seems to be running it happy as well. 

This closes: https://github.com/rackt/react-redux/issues/133

Let me know if there is anything else I should be doing for PRs and I'm happy to do so! 