### PR TITLE
connect doesn't apply ref to stateless component

### DIFF
--- a/src/components/createConnect.js
+++ b/src/components/createConnect.js
@@ -77,6 +77,8 @@ export default function createConnect(React) {
     }
 
     return function wrapWithConnect(WrappedComponent) {
+      let isStateless = !(WrappedComponent.prototype && WrappedComponent.prototype.isReactComponent) || !('prototype' in WrappedComponent);
+
       class Connect extends Component {
 
         shouldComponentUpdate(nextProps, nextState) {
@@ -199,6 +201,10 @@ export default function createConnect(React) {
         }
 
         render() {
+          if (isStateless) {
+            return <WrappedComponent {...this.nextState} />;
+          }
+
           return (
             <WrappedComponent ref='wrappedInstance'
                               {...this.nextState} />

--- a/test/components/connect.spec.js
+++ b/test/components/connect.spec.js
@@ -1117,6 +1117,21 @@ describe('React', () => {
       expect(decorated.refs.wrappedInstance.someInstanceMethod()).toBe(someData);
     });
 
+    it('should not add refs to wrapped instance if stateless', () => {
+      const store = createStore(() => ({}));
+      const decorator = connect(state => state);
+      const Decorated = decorator(() => <div/>);
+
+      const tree = TestUtils.renderIntoDocument(
+        <ProviderMock store={store}>
+          <Decorated />
+        </ProviderMock>
+      );
+
+      const decorated = TestUtils.findRenderedComponentWithType(tree, Decorated);
+      expect(Object.keys(decorated.refs)).toExclude('wrappedInstance');
+    });
+
     it('should wrap impure components without supressing updates', () => {
       const store = createStore(() => ({}));
 

--- a/test/components/connect.spec.js
+++ b/test/components/connect.spec.js
@@ -1132,6 +1132,30 @@ describe('React', () => {
       expect(Object.keys(decorated.refs)).toExclude('wrappedInstance');
     });
 
+    it('should consider module pattern of non-Component-inheriting classes stateful', () => {
+      function MyComponent(initialProps) {
+        return {
+          state: { value: initialProps.initialValue },
+          render: function render() {
+            return <span className={this.state.value} />;
+          }
+        };
+      }
+
+      const store = createStore(() => ({}));
+      const decorator = connect(state => state);
+      const Decorated = decorator(() => <MyComponent/>);
+
+      const tree = TestUtils.renderIntoDocument(
+        <ProviderMock store={store}>
+          <Decorated />
+        </ProviderMock>
+      );
+
+      const decorated = TestUtils.findRenderedComponentWithType(tree, Decorated);
+      expect(Object.keys(decorated.refs)).toInclude('wrappedInstance');
+    });
+
     it('should wrap impure components without supressing updates', () => {
       const store = createStore(() => ({}));
 


### PR DESCRIPTION
Took a stab at #141 

Probably would be better to create the render function beforehand, instead of hitting that conditional every render. Just getting this out there for discussion.

Worth noting that the detection isn't perfect, but solves the case mentioned here, and keeps the current test for wrappedInstance ref passing. We'd have to instantiate the component to know for sure, but this might be good enough.

Pretty much stole the check from ReactCompositeComponent