### PR TITLE
Switched from React to ReactDOM when calling 'findDOMNode'

### DIFF
--- a/src/components/connect.js
+++ b/src/components/connect.js
@@ -231,4 +231,4 @@ export default function connect(mapStateToProps, mapDispatchToProps, mergeProps,
 
     return hoistStatics(Connect, WrappedComponent);
   };
-};
+}

--- a/test/components/connect.spec.js
+++ b/test/components/connect.spec.js
@@ -1276,7 +1276,7 @@ describe('React', () => {
 
       // setState calls DOM handlers are batched
       const container = TestUtils.findRenderedComponentWithType(tree, Container);
-      const node = React.findDOMNode(container.getWrappedInstance().refs.button);
+      const node = ReactDOM.findDOMNode(container.getWrappedInstance().refs.button);
       TestUtils.Simulate.click(node);
       expect(childMapStateInvokes).toBe(4);
 

--- a/test/components/connect.spec.js
+++ b/test/components/connect.spec.js
@@ -1276,7 +1276,7 @@ describe('React', () => {
 
       // setState calls DOM handlers are batched
       const container = TestUtils.findRenderedComponentWithType(tree, Container);
-      const node = ReactDOM.findDOMNode(container.getWrappedInstance().refs.button);
+      const node = container.getWrappedInstance().refs.button;
       TestUtils.Simulate.click(node);
       expect(childMapStateInvokes).toBe(4);
 


### PR DESCRIPTION
It applies to a single test case only. :smirk: