### PR TITLE
Add option to turn connect refs on and off

### DIFF
--- a/src/components/createConnect.js
+++ b/src/components/createConnect.js
@@ -112,6 +112,7 @@ export default function createConnect(React) {
           super(props, context);
           this.version = version;
           this.store = props.store || context.store;
+          this.connectOptions = {...context.connectOptions, ...props.connectOptions};
 
           invariant(this.store,
             `Could not find "store" in either the context or ` +
@@ -199,20 +200,22 @@ export default function createConnect(React) {
         }
 
         render() {
-          return (
-            <WrappedComponent ref='wrappedInstance'
-                              {...this.nextState} />
-          );
+          if (this.connectOptions.useRefs) {
+            return <WrappedComponent {...this.nextState} ref='wrappedInstance' />;
+          }
+          return <WrappedComponent {...this.nextState} />;
         }
       }
 
       Connect.displayName = `Connect(${getDisplayName(WrappedComponent)})`;
       Connect.WrappedComponent = WrappedComponent;
       Connect.contextTypes = {
-        store: storeShape
+        store: storeShape,
+        connectOptions: PropTypes.object.isRequired
       };
       Connect.propTypes = {
-        store: storeShape
+        store: storeShape,
+        connectOptions: PropTypes.object
       };
 
       if (process.env.NODE_ENV !== 'production') {

--- a/src/components/createProvider.js
+++ b/src/components/createProvider.js
@@ -61,12 +61,16 @@ export default function createProvider(React) {
 
   class Provider extends Component {
     getChildContext() {
-      return { store: this.store };
+      return {
+        store: this.store,
+        connectOptions: this.connectOptions
+      };
     }
 
     constructor(props, context) {
       super(props, context);
       this.store = props.store;
+      this.connectOptions = {...this.defaultConnectOptions, ...props.connectOptions};
     }
 
     componentWillReceiveProps(nextProps) {
@@ -93,14 +97,19 @@ export default function createProvider(React) {
   }
 
   Provider.childContextTypes = {
-    store: storeShape.isRequired
+    store: storeShape.isRequired,
+    connectOptions: PropTypes.object.isRequired
   };
   Provider.propTypes = {
     store: storeShape.isRequired,
     children: (requireFunctionChild ?
       PropTypes.func :
       PropTypes.element
-    ).isRequired
+    ).isRequired,
+    connectOptions: PropTypes.object
+  };
+  Provider.defaultConnectOptions = {
+    useRefs: true
   };
 
   return Provider;


### PR DESCRIPTION
An alternative way to deal with #141

Add prop `connectOptions` to Provider (put in context). Default connect options are `{useRefs: true}`, and options can be overwritten on each connect instance (so refs can be turned on or off globally and locally). If refs are used for testing purposes only, then it gives the ability to not have them in production.

`useRefs` is by default true to avoid introducing a breaking change, but IMO it would be best if it is false by default (and turned on for testing and debugging purposes).