### PR TITLE
Drop dependency on mocha-jsdom in favor of explicit solution

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "clean": "rimraf lib dist coverage",
     "lint": "eslint src test",
     "prepublish": "npm run clean && npm run build",
-    "test": "mocha --compilers js:babel/register --recursive",
+    "test": "mocha --compilers js:babel/register --recursive --require ./test/setup.js",
     "test:watch": "npm test -- --watch",
     "test:cov": "babel-node ./node_modules/isparta/bin/isparta cover ./node_modules/mocha/bin/_mocha -- --recursive"
   },
@@ -49,7 +49,6 @@
     "istanbul": "^0.3.17",
     "jsdom": "~5.4.3",
     "mocha": "^2.2.5",
-    "mocha-jsdom": "~0.4.0",
     "react": "^0.14.0",
     "react-addons-test-utils": "^0.14.0",
     "react-dom": "^0.14.0",

--- a/test/components/Provider.spec.js
+++ b/test/components/Provider.spec.js
@@ -1,5 +1,4 @@
 import expect from 'expect';
-import jsdom from 'mocha-jsdom';
 import React, { PropTypes, Component } from 'react';
 import TestUtils from 'react-addons-test-utils';
 import { createStore } from 'redux';
@@ -7,8 +6,6 @@ import { Provider } from '../../src/index';
 
 describe('React', () => {
   describe('Provider', () => {
-    jsdom();
-
     class Child extends Component {
       static contextTypes = {
         store: PropTypes.object.isRequired

--- a/test/components/connect.spec.js
+++ b/test/components/connect.spec.js
@@ -1,5 +1,4 @@
 import expect from 'expect';
-import jsdom from 'mocha-jsdom';
 import React, { createClass, Children, PropTypes, Component } from 'react';
 import ReactDOM from 'react-dom';
 import TestUtils from 'react-addons-test-utils';
@@ -8,8 +7,6 @@ import { connect } from '../../src/index';
 
 describe('React', () => {
   describe('connect', () => {
-    jsdom();
-
     class Passthrough extends Component {
       render() {
         return <div {...this.props} />;

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,0 +1,5 @@
+import { jsdom } from 'jsdom';
+
+global.document = jsdom('<!doctype html><html><body></body></html>');
+global.window = document.defaultView;
+global.navigator = global.window.navigator;


### PR DESCRIPTION
Instead of doing something mysterious with `mocha-jsdom` we now do as suggested in https://github.com/facebook/react/issues/5046#issuecomment-146222515.