### PR TITLE
Use stateless functional component in dumb example

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -42,16 +42,14 @@ It is advisable that only top-level components of your app (such as route handle
 Let’s say we have a `<Counter />` “dumb” component with a number `value` prop, and an `onIncrement` function prop that it will call when user presses an “Increment” button:
 
 ```js
-import { Component } from 'react';
+import React from 'react'
 
-export default class Counter extends Component {
-  render() {
-    return (
-      <button onClick={this.props.onIncrement}>
-        {this.props.value}
-      </button>
-    )
-  }
+export default function Counter(props) {
+  return (
+    <button onClick={props.onIncrement}>
+      {props.value}
+    </button>
+  )
 }
 ```
 


### PR DESCRIPTION
"Dumb" components like this example seem to be an obvious place to use React 0.14 stateless functional components. This PR changes the example to use one.

I don't know if a stateful component was a concious choice, but I would prefer stateless in this situation and I think it should be considered for the example.