### PR TITLE
Add stateThunk / dispatchThunk options

### DIFF
--- a/src/components/connect.js
+++ b/src/components/connect.js
@@ -22,15 +22,15 @@ function getDisplayName(WrappedComponent) {
 let nextVersion = 0
 
 export default function connect(mapStateToProps, mapDispatchToProps, mergeProps, options = {}) {
-  const { pure = true, withRef = false, mapStateThunk = false, mapDispatchThunk = false } = options
+  const { pure = true, withRef = false, stateThunk = false, dispatchThunk = false } = options
   const shouldSubscribe = Boolean(mapStateToProps)
   const finalMapStateToProps = mapStateToProps || defaultMapStateToProps
   const finalMapDispatchToProps = isPlainObject(mapDispatchToProps) ?
     wrapActionCreators(mapDispatchToProps) :
     mapDispatchToProps || defaultMapDispatchToProps
   const finalMergeProps = mergeProps || defaultMergeProps
-  const shouldUpdateStateProps = mapStateThunk || finalMapStateToProps.length > 1
-  const shouldUpdateDispatchProps = mapDispatchThunk || finalMapDispatchToProps.length > 1
+  const shouldUpdateStateProps = stateThunk || finalMapStateToProps.length > 1
+  const shouldUpdateDispatchProps = dispatchThunk || finalMapDispatchToProps.length > 1
 
   // Helps track hot reloading.
   const version = nextVersion++
@@ -124,9 +124,9 @@ export default function connect(mapStateToProps, mapDispatchToProps, mergeProps,
       }
 
       updateThunks() {
-        this.finalMapStateToProps = mapStateThunk
+        this.finalMapStateToProps = stateThunk
           ? finalMapStateToProps() : finalMapStateToProps
-        this.finalMapDispatchToProps = mapDispatchThunk
+        this.finalMapDispatchToProps = dispatchThunk
           ? finalMapDispatchToProps() : finalMapDispatchToProps
       }
 

--- a/src/components/connect.js
+++ b/src/components/connect.js
@@ -22,15 +22,15 @@ function getDisplayName(WrappedComponent) {
 let nextVersion = 0
 
 export default function connect(mapStateToProps, mapDispatchToProps, mergeProps, options = {}) {
-  const { pure = true, withRef = false, stateThunk = false, dispatchThunk = false } = options
+  const { pure = true, withRef = false } = options
   const shouldSubscribe = Boolean(mapStateToProps)
   const finalMapStateToProps = mapStateToProps || defaultMapStateToProps
   const finalMapDispatchToProps = isPlainObject(mapDispatchToProps) ?
     wrapActionCreators(mapDispatchToProps) :
     mapDispatchToProps || defaultMapDispatchToProps
   const finalMergeProps = mergeProps || defaultMergeProps
-  const shouldUpdateStateProps = stateThunk || finalMapStateToProps.length > 1
-  const shouldUpdateDispatchProps = dispatchThunk || finalMapDispatchToProps.length > 1
+  const shouldUpdateStateProps = finalMapStateToProps.length > 1
+  const shouldUpdateDispatchProps = finalMapDispatchToProps.length > 1
 
   // Helps track hot reloading.
   const version = nextVersion++
@@ -116,18 +116,16 @@ export default function connect(mapStateToProps, mapDispatchToProps, mergeProps,
           `or explicitly pass "store" as a prop to "${this.constructor.displayName}".`
         )
 
-        this.updateThunks()
+        this.assignMapFunctions()
         this.stateProps = computeStateProps(this.finalMapStateToProps, this.store, props)
         this.dispatchProps = computeDispatchProps(this.finalMapDispatchToProps, this.store, props)
         this.state = { storeState: null }
         this.updateState()
       }
 
-      updateThunks() {
-        this.finalMapStateToProps = stateThunk
-          ? finalMapStateToProps() : finalMapStateToProps
-        this.finalMapDispatchToProps = dispatchThunk
-          ? finalMapDispatchToProps() : finalMapDispatchToProps
+      assignMapFunctions() {
+        this.finalMapStateToProps = finalMapStateToProps
+        this.finalMapDispatchToProps = finalMapDispatchToProps
       }
 
       computeNextState(props = this.props) {
@@ -234,7 +232,7 @@ export default function connect(mapStateToProps, mapDispatchToProps, mergeProps,
         this.version = version
 
         // Update the state and bindings.
-        this.updateThunks()
+        this.assignMapFunctions()
         this.trySubscribe()
         this.updateStateProps()
         this.updateDispatchProps()

--- a/test/components/connect.spec.js
+++ b/test/components/connect.spec.js
@@ -1371,7 +1371,7 @@ describe('React', () => {
       expect(renderCalls).toBe(1)
     })
 
-    it('accepts a wrapMapState option for configuring mapStateToProps for the component', () => {
+    it('accepts mapStateThunk for a unique mapStateToProps per component', () => {
 
       const store = createStore(() => ({
         prefix: 'name: '
@@ -1399,7 +1399,7 @@ describe('React', () => {
         return { value: props.prefix + state.name }
       }
 
-      @connect(() => memoize(computeValue), null, null, { wrapMapState: (fn) => fn() })
+      @connect(() => memoize(computeValue), null, null, { mapStateThunk: true })
       class Container extends Component {
         componentDidMount() {
           this.forceUpdate()

--- a/test/components/connect.spec.js
+++ b/test/components/connect.spec.js
@@ -4,6 +4,7 @@ import ReactDOM from 'react-dom'
 import TestUtils from 'react-addons-test-utils'
 import { createStore } from 'redux'
 import { connect } from '../../src/index'
+import shallowEqual from '../../src/utils/shallowEqual'
 
 describe('React', () => {
   describe('connect', () => {
@@ -190,7 +191,7 @@ describe('React', () => {
           return (
             <ProviderMock store={store}>
               <ConnectContainer bar={this.state.bar} />
-             </ProviderMock>
+            </ProviderMock>
           )
         }
       }
@@ -1368,6 +1369,59 @@ describe('React', () => {
       expect(mapStateCalls).toBe(3)
       // But render is not because it did not make any actual changes
       expect(renderCalls).toBe(1)
+    })
+
+    it('accepts a wrapMapState option for configuring mapStateToProps for the component', () => {
+
+      const store = createStore(() => ({
+        prefix: 'name: '
+      }))
+      let memoizeHits = 0
+      let memoizeMisses = 0
+      let renderCalls = 0
+
+      function memoize(func) {
+        let lastResult, lastArgs = lastResult = null
+        return (...args) => {
+          if (lastArgs && args.every((value, index) => shallowEqual(value, lastArgs[index]))) {
+            memoizeHits++
+            return lastResult
+          } else if (lastArgs) {
+            memoizeMisses++
+          }
+          lastArgs = args
+          lastResult = func(...args)
+          return lastResult
+        }
+      }
+
+      function computeValue(state, props) {
+        return { value: props.prefix + state.name }
+      }
+
+      @connect(() => memoize(computeValue), null, null, { wrapMapState: (fn) => fn() })
+      class Container extends Component {
+        componentDidMount() {
+          this.forceUpdate()
+        }
+        render() {
+          renderCalls++
+          return <div>{this.props.value}</div>
+        }
+      }
+
+      TestUtils.renderIntoDocument(
+        <ProviderMock store={store}>
+          <div>
+            <Container name="one" />
+            <Container name="two" />
+          </div>
+        </ProviderMock>
+      )
+
+      expect(renderCalls).toEqual(4)
+      expect(memoizeHits).toEqual(2)
+      expect(memoizeMisses).toEqual(0)
     })
   })
 })

--- a/test/components/connect.spec.js
+++ b/test/components/connect.spec.js
@@ -1399,7 +1399,7 @@ describe('React', () => {
         return { value: props.prefix + state.name }
       }
 
-      @connect(() => memoize(computeValue), null, null, { mapStateThunk: true })
+      @connect(() => memoize(computeValue), null, null, { stateThunk: true })
       class Container extends Component {
         componentDidMount() {
           this.forceUpdate()

--- a/test/components/connect.spec.js
+++ b/test/components/connect.spec.js
@@ -1371,7 +1371,7 @@ describe('React', () => {
       expect(renderCalls).toBe(1)
     })
 
-    it('accepts mapStateThunk for a unique mapStateToProps per component', () => {
+    it('defines finalMapStateToProps on the component', () => {
 
       const store = createStore(() => ({
         prefix: 'name: '
@@ -1395,11 +1395,21 @@ describe('React', () => {
         }
       }
 
+      function memoizer(WrappedComponent) {
+        let assignMapFunctions = WrappedComponent.prototype.assignMapFunctions
+        WrappedComponent.prototype.assignMapFunctions = function () {
+          assignMapFunctions.call(this)
+          this.finalMapStateToProps = memoize(this.finalMapStateToProps)
+        }
+        return WrappedComponent
+      }
+
       function computeValue(state, props) {
         return { value: props.prefix + state.name }
       }
 
-      @connect(() => memoize(computeValue), null, null, { stateThunk: true })
+      @memoizer
+      @connect(computeValue, null, null, { stateThunk: true })
       class Container extends Component {
         componentDidMount() {
           this.forceUpdate()


### PR DESCRIPTION
Adds two new options, `stateThunk` and `dispatchThunk`. When set to true, it signifies that the value of `mapStateToProps` or `mapDispatchToProps` are thunks, called in the constructor & return values stored on the connected component class.

The use case comes from reselect - I noticed that although functions are memoized, when using `props` it destroys the utility of the memoziation feature. The idea here is that each connected component would return a unique memoized selector, rather than sharing one between all instances of a component and ending up with a ton of cache misses.

So instead of:

```js
@connect(createSelector(...fns))
```

You'd do:

```js
@connect(() => createSelector(...fns), null, null, {stateThunk: true})
```
