### PR TITLE
Adds memoize option, defaulting to no memoization

### DIFF
--- a/test/components/connect.spec.js
+++ b/test/components/connect.spec.js
@@ -4,6 +4,7 @@ import ReactDOM from 'react-dom'
 import TestUtils from 'react-addons-test-utils'
 import { createStore } from 'redux'
 import { connect } from '../../src/index'
+import shallowEqual from '../../src/utils/shallowEqual'
 
 describe('React', () => {
   describe('connect', () => {
@@ -1369,5 +1370,59 @@ describe('React', () => {
       // But render is not because it did not make any actual changes
       expect(renderCalls).toBe(1)
     })
+
+    it('defines finalMapStateToProps on the component', () => {
+
+      const store = createStore(() => ({
+        prefix: 'name: '
+      }))
+      let memoizeHits = 0
+      let memoizeMisses = 0
+      let renderCalls = 0
+
+      function memoize(func) {
+        let lastResult, lastArgs = lastResult = null
+        return (...args) => {
+          if (lastArgs && args.every((value, index) => shallowEqual(value, lastArgs[index]))) {
+            memoizeHits++
+            return lastResult
+          } else if (lastArgs) {
+            memoizeMisses++
+          }
+          lastArgs = args
+          lastResult = func(...args)
+          return lastResult
+        }
+      }
+
+      function selector(state, props) {
+        return { value: props.prefix + state.name }
+      }
+
+      @connect(selector, null, null, { memoize })
+      class Container extends Component {
+        componentDidMount() {
+          this.forceUpdate()
+        }
+        render() {
+          renderCalls++
+          return <div>{this.props.value}</div>
+        }
+      }
+
+      TestUtils.renderIntoDocument(
+        <ProviderMock store={store}>
+          <div>
+            <Container name="one" />
+            <Container name="two" />
+          </div>
+        </ProviderMock>
+      )
+
+      expect(renderCalls).toEqual(4)
+      expect(memoizeHits).toEqual(2)
+      expect(memoizeMisses).toEqual(0)
+    })
+
   })
 })


### PR DESCRIPTION
So ultimate goal of #179 was to be able to add a layer of memoization on the selector - this PR does just that, if there is a function provided as a `memoize` option, the selector is passed through that function at instantiation and attached to the component instance. If `memoize` option is not provided ~~the default is identity~~ the function is attached directly to the component.

I moved a bit of the construction of the class to `componentWillMount` so we have a method to call in `componentWillUpdate` to re-attach the functions on hot reloading.