### PR TITLE
fix length comparisons on xxxToProps functions

### DIFF
--- a/src/components/connect.js
+++ b/src/components/connect.js
@@ -28,8 +28,8 @@ export default function connect(mapStateToProps, mapDispatchToProps, mergeProps,
     wrapActionCreators(mapDispatchToProps) :
     mapDispatchToProps || defaultMapDispatchToProps
   const finalMergeProps = mergeProps || defaultMergeProps
-  const shouldUpdateStateProps = finalMapStateToProps.length > 1
-  const shouldUpdateDispatchProps = finalMapDispatchToProps.length > 1
+  const shouldUpdateStateProps = finalMapStateToProps.length !== 1
+  const shouldUpdateDispatchProps = finalMapDispatchToProps.length !== 1
   const { pure = true, withRef = false } = options
 
   // Helps track hot reloading.

--- a/test/components/connect.spec.js
+++ b/test/components/connect.spec.js
@@ -426,10 +426,12 @@ describe('React', () => {
 
       let invocationCount = 0
 
-      @connect(() => {
+      /*eslint-disable no-unused-vars */
+      @connect((arg1) => {
         invocationCount++
         return {}
       })
+      /*eslint-enable no-unused-vars */
       class WithoutProps extends Component {
         render() {
           return <Passthrough {...this.props}/>
@@ -524,10 +526,12 @@ describe('React', () => {
 
       let invocationCount = 0
 
-      @connect(null, () => {
+      /*eslint-disable no-unused-vars */
+      @connect(null, (arg1) => {
         invocationCount++
         return {}
       })
+      /*eslint-enable no-unused-vars */
       class WithoutProps extends Component {
         render() {
           return <Passthrough {...this.props}/>

--- a/test/components/connect.spec.js
+++ b/test/components/connect.spec.js
@@ -469,6 +469,53 @@ describe('React', () => {
       expect(invocationCount).toEqual(2)
     })
 
+    it('should invoke mapState every time props are changed if it has zero arguments', () => {
+      const store = createStore(stringBuilder)
+
+      let invocationCount = 0
+
+      @connect(() => {
+        invocationCount++
+        return {}
+      })
+
+      class WithoutProps extends Component {
+        render() {
+          return <Passthrough {...this.props}/>
+        }
+      }
+
+      class OuterComponent extends Component {
+        constructor() {
+          super()
+          this.state = { foo: 'FOO' }
+        }
+
+        setFoo(foo) {
+          this.setState({ foo })
+        }
+
+        render() {
+          return (
+            <div>
+              <WithoutProps {...this.state} />
+            </div>
+          )
+        }
+      }
+
+      let outerComponent
+      TestUtils.renderIntoDocument(
+        <ProviderMock store={store}>
+          <OuterComponent ref={c => outerComponent = c} />
+        </ProviderMock>
+      )
+      outerComponent.setFoo('BAR')
+      outerComponent.setFoo('DID')
+
+      expect(invocationCount).toEqual(4)
+    })
+
     it('should invoke mapState every time props are changed if it has a second argument', () => {
       const store = createStore(stringBuilder)
 
@@ -568,6 +615,54 @@ describe('React', () => {
       outerComponent.setFoo('DID')
 
       expect(invocationCount).toEqual(1)
+    })
+
+    it('should invoke mapDispatch every time props are changed if it has zero arguments', () => {
+      const store = createStore(stringBuilder)
+
+      let invocationCount = 0
+
+      @connect(null, () => {
+        invocationCount++
+        return {}
+      })
+
+      class WithoutProps extends Component {
+        render() {
+          return <Passthrough {...this.props}/>
+        }
+      }
+
+      class OuterComponent extends Component {
+        constructor() {
+          super()
+          this.state = { foo: 'FOO' }
+        }
+
+        setFoo(foo) {
+          this.setState({ foo })
+        }
+
+        render() {
+          return (
+            <div>
+              <WithoutProps {...this.state} />
+            </div>
+          )
+        }
+      }
+
+      let outerComponent
+      TestUtils.renderIntoDocument(
+        <ProviderMock store={store}>
+          <OuterComponent ref={c => outerComponent = c} />
+        </ProviderMock>
+      )
+
+      outerComponent.setFoo('BAR')
+      outerComponent.setFoo('DID')
+
+      expect(invocationCount).toEqual(3)
     })
 
     it('should invoke mapDispatch every time props are changed if it has a second argument', () => {


### PR DESCRIPTION
Testing finalMap{State|Dispatch}ToProps.length > 1 breaks when these functions are wrapped in generic decorator functions. Instead, test for !== 1.

For example, let's say I wanted to write a decorator function that logs function invocation like so:
```
function traceExecution(fn) {
  const name = fn.name;
  return function() {
    console.log('ENTER: ', name);
    const result = fn.apply(this, arguments);
    console.log('LEAVE: ', name, ' --> ', result);
    return result;
  }
}
```
Then, I want to wrap my mapStateToProps and mapDispatchToProps functions with traceExecution and pass it to connect:
```
function mapStateToProps(state, props) { /* stuff here */}
function mapDispatchToProps(dispatch, props) { /* stuff here */}
const connector = connect(traceExecution(mapStateToProps), traceExecution(mapDispatchToProps))
```
This would not work without these fixes, since the functions returned by the decorator have arity 0 and would fail the "> 1" length test.

By changing the arity test to be "!== 1" instead of "> 1", you enable this scenario to work as expected.