### PR TITLE
Fix CI build errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "iojs-2"
+  - "5"
 script:
   - npm run lint
   - npm test

--- a/test/components/connect.spec.js
+++ b/test/components/connect.spec.js
@@ -1101,9 +1101,7 @@ describe('React', () => {
       expect(() =>
         TestUtils.renderIntoDocument(<Decorated />)
       ).toThrow(
-        'Invariant Violation: Could not find "store" in either the context ' +
-        'or props of "Connect(Container)". Either wrap the root component in a ' +
-        '<Provider>, or explicitly pass "store" as a prop to "Connect(Container)".'
+        /Could not find "store"/
       )
     })
 


### PR DESCRIPTION
Bumped node version to 5 to fix lint error.
Made failing test 'should throw an error if the store is not in the props or context' not have to match the exact error string as suggested [here](https://github.com/rackt/react-redux/pull/196#issuecomment-160009368) (thanks @schmeedy!) 