### PR TITLE
Use files in package.json

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,0 @@
-examples

--- a/package.json
+++ b/package.json
@@ -20,6 +20,11 @@
     "type": "git",
     "url": "https://github.com/gaearon/react-redux.git"
   },
+  "files": [
+    "dist",
+    "lib",
+    "src"
+  ],
   "keywords": [
     "react",
     "reactjs",


### PR DESCRIPTION
Copying the approach in https://github.com/rackt/redux/pull/1039. Need to get rid of the `.babelrc` file for React Native 0.16.0