### PR TITLE
Alter test case for dispatching in componentWillMount

### DIFF
--- a/test/components/connect.spec.js
+++ b/test/components/connect.spec.js
@@ -142,12 +142,12 @@ describe('React', () => {
         }
 
         render() {
-          expect(this.props.string).toBe('a');
+          expect(this.props.string).toBe('a')
           return <Passthrough {...this.props}/>
         }
       }
 
-      const tree = TestUtils.renderIntoDocument(
+      TestUtils.renderIntoDocument(
         <ProviderMock store={store}>
           <Container />
         </ProviderMock>

--- a/test/components/connect.spec.js
+++ b/test/components/connect.spec.js
@@ -142,6 +142,7 @@ describe('React', () => {
         }
 
         render() {
+          expect(this.props.string).toBe('a');
           return <Passthrough {...this.props}/>
         }
       }
@@ -151,9 +152,6 @@ describe('React', () => {
           <Container />
         </ProviderMock>
       )
-
-      const stub = TestUtils.findRenderedComponentWithType(tree, Passthrough)
-      expect(stub.props.string).toBe('a')
     })
 
     it('should handle additional prop changes in addition to slice', () => {


### PR DESCRIPTION
Test case for issue https://github.com/rackt/react-redux/issues/210.

I chose to edit the existing test rather than create a new test. The original test case in question looks like it tests dispatching in `componentWillMount`, but it doesn't actually check if the props make it into the component the first time it is rendered. So rather than keep it as it was, I changed it so it now properly tests (and fails).
