### PR TITLE
Move the side effects out of shouldComponentUpdate()

### DIFF
--- a/src/components/connect.js
+++ b/src/components/connect.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react'
+import React, { Component, createElement } from 'react'
 import storeShape from '../utils/storeShape'
 import shallowEqual from '../utils/shallowEqual'
 import isPlainObject from '../utils/isPlainObject'
@@ -229,14 +229,21 @@ export default function connect(mapStateToProps, mapDispatchToProps, mergeProps,
           haveMergedPropsChanged = false
         }
 
-        if (!haveMergedPropsChanged && this.renderedElement) {
-          return this.renderedElement
+        if (!haveMergedPropsChanged && renderedElement) {
+          return renderedElement
         }
 
-        const ref = withRef ? 'wrappedInstance' : null
-        this.renderedElement = (
-          <WrappedComponent {...this.mergedProps} ref={ref} />
-        )
+        if (withRef) {
+          this.renderedElement = createElement(WrappedComponent, {
+            ...this.mergedProps,
+            ref: 'wrappedInstance'
+          })
+        } else {
+          this.renderedElement = createElement(WrappedComponent,
+            this.mergedProps
+          )
+        }
+
         return this.renderedElement
       }
     }

--- a/test/components/connect.spec.js
+++ b/test/components/connect.spec.js
@@ -323,7 +323,7 @@ describe('React', () => {
           return (
             <ProviderMock store={store}>
               <ConnectContainer bar={this.state.bar} />
-             </ProviderMock>
+            </ProviderMock>
           )
         }
       }

--- a/test/components/connect.spec.js
+++ b/test/components/connect.spec.js
@@ -201,6 +201,44 @@ describe('React', () => {
       expect(stub.props.pass).toEqual('through')
     })
 
+    it('should handle unexpected prop changes with forceUpdate()', () => {
+      const store = createStore(() => ({}))
+
+      @connect(state => state)
+      class ConnectContainer extends Component {
+        render() {
+          return (
+            <Passthrough {...this.props} pass={this.props.bar} />
+          )
+        }
+      }
+
+      class Container extends Component {
+        constructor() {
+          super()
+          this.bar = 'baz'
+        }
+
+        componentDidMount() {
+          this.bar = 'foo'
+          this.forceUpdate()
+          this.c.forceUpdate()
+        }
+
+        render() {
+          return (
+            <ProviderMock store={store}>
+              <ConnectContainer bar={this.bar} ref={c => this.c = c} />
+            </ProviderMock>
+          )
+        }
+      }
+
+      const container = TestUtils.renderIntoDocument(<Container />)
+      const stub = TestUtils.findRenderedComponentWithType(container, Passthrough)
+      expect(stub.props.bar).toEqual('foo')
+    })
+
     it('should remove undefined props', () => {
       const store = createStore(() => ({}))
       let props = { x: true }


### PR DESCRIPTION
This attempts to completely remove any internal side effects from `shouldComponentUpdate()` because is not in line with how React tells us to treat it and [may not even be called in certain cases, e.g. during hot reloading](https://github.com/rackt/react-redux/issues/224).

I didn't touch any tests, and that they pass is a good sign because it means we didn't regress over #99 which is where those side effects were moved to `shouldComponentUpdate()`. Here, instead, I moved them to `render()`, and applied a different optimization (namely, returning a constant element) to achieve the same effect as `shouldComponentUpdate()` did while always calling `mapStateToProps` and `mapDispatchToProps` with up-to-date props.

I confirm this PR fixes #224. It should not regress on performance.

@epeli Would you like to review?