### PR TITLE
Clearified the "Don’t do this"

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -104,7 +104,7 @@ export default connect()(TodoApp)
 
 ##### Inject `dispatch` and every field in the global state
 
->Don’t do this! It kills any performance optimizations because `TodoApp` will rerender after every action.  
+>Don’t do this if you have several components connected to Redux in your application! It kills any performance optimizations because `TodoApp` will rerender after every action.  
 >It’s better to have more granular `connect()` on several components in your view hierarchy that each only  
 >listen to a relevant slice of the state.
 


### PR DESCRIPTION
I am a Redux beginner and I stumbled over the "Don't do this!" because I thought that injecting dispatch + every field in the global state should generally not be done - never.
After doing some research my understanding is that this is perfectly ok for applications with only one container component connected to Redux.
So my addition should clearify this.