### PR TITLE
removed redundant `package manager`

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ React Redux requires **React 0.14 or later.**
 npm install --save react-redux
 ```
 
-This assumes that you’re using [npm](http://npmjs.com/) package manager with a module bundler like [Webpack](http://webpack.github.io) or [Browserify](http://browserify.org/) to consume [CommonJS modules](http://webpack.github.io/docs/commonjs.html).
+This assumes that you’re using [npm](http://npmjs.com/) with a module bundler like [Webpack](http://webpack.github.io) or [Browserify](http://browserify.org/) to consume [CommonJS modules](http://webpack.github.io/docs/commonjs.html).
 
 If you don’t yet use [npm](http://npmjs.com/) or a modern module bundler, and would rather prefer a single-file [UMD](https://github.com/umdjs/umd) build that makes `ReactRedux` available as a global object, you can grab a pre-built version from [cdnjs](https://cdnjs.com/libraries/react-redux). We *don’t* recommend this approach for any serious application, as most of the libraries complementary to Redux are only available on [npm](http://npmjs.com/).
 


### PR DESCRIPTION
Just reading through the readme and picked up on this. [npm](https://www.npmjs.com/) is an acronym for Node Package Manager, so the phrase `npm package manager` essentially evaluates to `node package manager package manager`.

No sure that anyone else will care, but it was bugging me. It's like when people say 'ATM machine', or 'as ASAP as possible'.