### PR TITLE
use hoist-non-react-methods instead of hoist-non-react-statics

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "webpack": "^1.11.0"
   },
   "dependencies": {
-    "hoist-non-react-statics": "^1.0.3",
+    "hoist-non-react-methods": "^1.0.2",
     "invariant": "^2.0.0"
   },
   "peerDependencies": {

--- a/src/components/connect.js
+++ b/src/components/connect.js
@@ -3,8 +3,8 @@ const storeShape = require('../utils/storeShape')
 const shallowEqual = require('../utils/shallowEqual')
 const isPlainObject = require('../utils/isPlainObject')
 const wrapActionCreators = require('../utils/wrapActionCreators')
-const hoistStatics = require('hoist-non-react-statics')
 const invariant = require('invariant')
+import hoistMethods from 'hoist-non-react-methods'
 
 const defaultMapStateToProps = state => ({}) // eslint-disable-line no-unused-vars
 const defaultMapDispatchToProps = dispatch => ({ dispatch })
@@ -270,7 +270,7 @@ function connect(mapStateToProps, mapDispatchToProps, mergeProps, options = {}) 
       }
     }
 
-    return hoistStatics(Connect, WrappedComponent)
+    return hoistMethods(Connect, WrappedComponent, w => w.getWrappedInstance())
   }
 }
 

--- a/test/components/connect.spec.js
+++ b/test/components/connect.spec.js
@@ -1267,7 +1267,7 @@ describe('React', () => {
       )
     })
 
-    it('should return the instance of the wrapped component for use in calling child methods', () => {
+    it('should return the instance of the wrapped component with its child custom methods', () => {
       const store = createStore(() => ({}))
 
       const someData = {
@@ -1295,7 +1295,7 @@ describe('React', () => {
 
       const decorated = TestUtils.findRenderedComponentWithType(tree, Decorated)
 
-      expect(() => decorated.someInstanceMethod()).toThrow()
+      expect(decorated.someInstanceMethod()).toBe(someData)
       expect(decorated.getWrappedInstance().someInstanceMethod()).toBe(someData)
       expect(decorated.refs.wrappedInstance.someInstanceMethod()).toBe(someData)
     })


### PR DESCRIPTION
copy **all** wrapped component's methods (prototype and static except react methods) into the wrapper component.

so methods like `focus` on `@connect() class Composer { focus() { this.refs.input.focus } }` will still be available if `Composer` is `ref`ed somewhere else.

Original issue: https://github.com/rackt/react-redux/issues/267

`hoist-non-react-methods` is here: https://github.com/elado/hoist-non-react-methods