### PR TITLE
Rename 'store' context to 'redux' in order to support #268

### DIFF
--- a/src/components/Provider.js
+++ b/src/components/Provider.js
@@ -19,7 +19,7 @@ function warnAboutReceivingStore() {
 
 class Provider extends Component {
   getChildContext() {
-    return { store: this.store }
+    return { redux: this.store }
   }
 
   constructor(props, context) {
@@ -47,7 +47,7 @@ Provider.propTypes = {
   children: PropTypes.element.isRequired
 }
 Provider.childContextTypes = {
-  store: storeShape.isRequired
+  redux: storeShape.isRequired
 }
 
 module.exports = Provider

--- a/src/components/connect.js
+++ b/src/components/connect.js
@@ -82,10 +82,10 @@ function connect(mapStateToProps, mapDispatchToProps, mergeProps, options = {}) 
       constructor(props, context) {
         super(props, context)
         this.version = version
-        this.store = props.store || context.store
+        this.store = props.store || context.redux
 
         invariant(this.store,
-          `Could not find "store" in either the context or ` +
+          `Could not find "redux" in the context or "store" in the ` +
           `props of "${this.constructor.displayName}". ` +
           `Either wrap the root component in a <Provider>, ` +
           `or explicitly pass "store" as a prop to "${this.constructor.displayName}".`
@@ -251,7 +251,7 @@ function connect(mapStateToProps, mapDispatchToProps, mergeProps, options = {}) 
     Connect.displayName = `Connect(${getDisplayName(WrappedComponent)})`
     Connect.WrappedComponent = WrappedComponent
     Connect.contextTypes = {
-      store: storeShape
+      redux: storeShape
     }
     Connect.propTypes = {
       store: storeShape

--- a/test/components/Provider.spec.js
+++ b/test/components/Provider.spec.js
@@ -14,7 +14,7 @@ describe('React', () => {
     }
 
     Child.contextTypes = {
-      store: PropTypes.object.isRequired
+      redux: PropTypes.object.isRequired
     }
 
     it('should enforce a single child', () => {
@@ -60,7 +60,7 @@ describe('React', () => {
       expect(spy.calls.length).toBe(0)
 
       const child = TestUtils.findRenderedComponentWithType(tree, Child)
-      expect(child.context.store).toBe(store)
+      expect(child.context.redux).toBe(store)
     })
 
     it('should warn once when receiving a new store in props', () => {
@@ -84,13 +84,13 @@ describe('React', () => {
 
       const container = TestUtils.renderIntoDocument(<ProviderContainer />)
       const child = TestUtils.findRenderedComponentWithType(container, Child)
-      expect(child.context.store.getState()).toEqual(11)
+      expect(child.context.redux.getState()).toEqual(11)
 
       let spy = expect.spyOn(console, 'error')
       container.setState({ store: store2 })
       spy.destroy()
 
-      expect(child.context.store.getState()).toEqual(11)
+      expect(child.context.redux.getState()).toEqual(11)
       expect(spy.calls.length).toBe(1)
       expect(spy.calls[0].arguments[0]).toBe(
         '<Provider> does not support changing `store` on the fly. ' +
@@ -104,7 +104,7 @@ describe('React', () => {
       container.setState({ store: store3 })
       spy.destroy()
 
-      expect(child.context.store.getState()).toEqual(11)
+      expect(child.context.redux.getState()).toEqual(11)
       expect(spy.calls.length).toBe(0)
     })
   })

--- a/test/components/connect.spec.js
+++ b/test/components/connect.spec.js
@@ -15,7 +15,7 @@ describe('React', () => {
 
     class ProviderMock extends Component {
       getChildContext() {
-        return { store: this.props.store }
+        return { redux: this.props.store }
       }
 
       render() {
@@ -24,7 +24,7 @@ describe('React', () => {
     }
 
     ProviderMock.childContextTypes = {
-      store: PropTypes.object.isRequired
+      redux: PropTypes.object.isRequired
     }
 
     function stringBuilder(prev = '', action) {
@@ -50,7 +50,7 @@ describe('React', () => {
       )
 
       const container = TestUtils.findRenderedComponentWithType(tree, Container)
-      expect(container.context.store).toBe(store)
+      expect(container.context.redux).toBe(store)
     })
 
     it('should pass state and props to the given component', () => {
@@ -1239,7 +1239,7 @@ describe('React', () => {
       expect(() =>
         TestUtils.renderIntoDocument(<Decorated />)
       ).toThrow(
-        /Could not find "store"/
+        /Could not find "redux"/
       )
     })
 


### PR DESCRIPTION
The store is set on on the context with the name `store` which is fine in most cases but since the context is global there are cases when you need it to be more specific.
I have an existent app which I want to port to Redux incrementally but it already has something called store on the context. 
The proposed solution here is to rename `store` to `redux` as per #268 