### PR TITLE
Upgrade to babel-eslint@5.0.0-beta9 to fix build

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "babel-cli": "^6.3.17",
     "babel-core": "^6.3.26",
-    "babel-eslint": "^5.0.0-beta4",
+    "babel-eslint": "^5.0.0-beta9",
     "babel-loader": "^6.2.0",
     "babel-plugin-transform-decorators-legacy": "^1.2.0",
     "babel-preset-es2015-loose": "^6.1.4",


### PR DESCRIPTION
The build is [currently broken](https://travis-ci.org/rackt/react-redux/builds/106281154#L739-L749) because of an [issue](https://github.com/babel/babel-eslint/issues/243) with babel-eslint. This bumps the version to pick up the fix.