### PR TITLE
Update connect to make it more extensible

### DIFF
--- a/src/components/connect.js
+++ b/src/components/connect.js
@@ -6,6 +6,8 @@ import isPlainObject from 'lodash/isPlainObject'
 import hoistStatics from 'hoist-non-react-statics'
 import invariant from 'invariant'
 
+
+
 const defaultMapStateToProps = state => ({}) // eslint-disable-line no-unused-vars
 const defaultMapDispatchToProps = dispatch => ({ dispatch })
 const defaultMergeProps = (stateProps, dispatchProps, parentProps) => ({
@@ -31,281 +33,300 @@ function checkStateShape(stateProps, dispatch) {
 // Helps track hot reloading.
 let nextVersion = 0
 
-export default function connect(mapStateToProps, mapDispatchToProps, mergeProps, options = {}) {
-  const shouldSubscribe = Boolean(mapStateToProps)
-  const mapState = mapStateToProps || defaultMapStateToProps
-  const mapDispatch = isPlainObject(mapDispatchToProps) ?
-    wrapActionCreators(mapDispatchToProps) :
-    mapDispatchToProps || defaultMapDispatchToProps
+export function createConnect(ConnectComponentClass) {
+  return (mapStateToProps, mapDispatchToProps, mergeProps, options = {}) => {
+    const shouldSubscribe = Boolean(mapStateToProps)
+    const mapState = mapStateToProps || defaultMapStateToProps
+    const mapDispatch = isPlainObject(mapDispatchToProps) ?
+      wrapActionCreators(mapDispatchToProps) :
+      mapDispatchToProps || defaultMapDispatchToProps
 
-  const finalMergeProps = mergeProps || defaultMergeProps
-  const checkMergedEquals = finalMergeProps !== defaultMergeProps
-  const { pure = true, withRef = false } = options
+    const finalMergeProps = mergeProps || defaultMergeProps
+    const checkMergedEquals = finalMergeProps !== defaultMergeProps
+    const { pure = true, withRef = false } = options
 
-  // Helps track hot reloading.
-  const version = nextVersion++
+    // Helps track hot reloading.
+    const version = nextVersion++
 
-  function computeMergedProps(stateProps, dispatchProps, parentProps) {
-    const mergedProps = finalMergeProps(stateProps, dispatchProps, parentProps)
-    invariant(
-      isPlainObject(mergedProps),
-      '`mergeProps` must return an object. Instead received %s.',
-      mergedProps
-    )
-    return mergedProps
-  }
-
-  return function wrapWithConnect(WrappedComponent) {
-    class Connect extends Component {
-      shouldComponentUpdate() {
-        return !pure || this.haveOwnPropsChanged || this.hasStoreStateChanged
-      }
-
-      constructor(props, context) {
-        super(props, context)
-        this.version = version
-        this.store = props.store || context.store
-
-        invariant(this.store,
-          `Could not find "store" in either the context or ` +
-          `props of "${this.constructor.displayName}". ` +
-          `Either wrap the root component in a <Provider>, ` +
-          `or explicitly pass "store" as a prop to "${this.constructor.displayName}".`
-        )
-
-        const storeState = this.store.getState()
-        this.state = { storeState }
-        this.clearCache()
-      }
-
-      computeStateProps(store, props) {
-        if (!this.finalMapStateToProps) {
-          return this.configureFinalMapState(store, props)
-        }
-
-        const state = store.getState()
-        const stateProps = this.doStatePropsDependOnOwnProps ?
-          this.finalMapStateToProps(state, props) :
-          this.finalMapStateToProps(state)
-
-        return checkStateShape(stateProps)
-      }
-
-      configureFinalMapState(store, props) {
-        const mappedState = mapState(store.getState(), props)
-        const isFactory = typeof mappedState === 'function'
-
-        this.finalMapStateToProps = isFactory ? mappedState : mapState
-        this.doStatePropsDependOnOwnProps = this.finalMapStateToProps.length !== 1
-
-        return isFactory ?
-          this.computeStateProps(store, props) :
-          checkStateShape(mappedState)
-      }
-
-      computeDispatchProps(store, props) {
-        if (!this.finalMapDispatchToProps) {
-          return this.configureFinalMapDispatch(store, props)
-        }
-
-        const { dispatch } = store
-        const dispatchProps = this.doDispatchPropsDependOnOwnProps ?
-          this.finalMapDispatchToProps(dispatch, props) :
-          this.finalMapDispatchToProps(dispatch)
-
-        return checkStateShape(dispatchProps, true)
-      }
-
-      configureFinalMapDispatch(store, props) {
-        const mappedDispatch = mapDispatch(store.dispatch, props)
-        const isFactory = typeof mappedDispatch === 'function'
-
-        this.finalMapDispatchToProps = isFactory ? mappedDispatch : mapDispatch
-        this.doDispatchPropsDependOnOwnProps = this.finalMapDispatchToProps.length !== 1
-
-        return isFactory ?
-          this.computeDispatchProps(store, props) :
-          checkStateShape(mappedDispatch, true)
-      }
-
-      updateStatePropsIfNeeded() {
-        const nextStateProps = this.computeStateProps(this.store, this.props)
-        if (this.stateProps && shallowEqual(nextStateProps, this.stateProps)) {
-          return false
-        }
-
-        this.stateProps = nextStateProps
-        return true
-      }
-
-      updateDispatchPropsIfNeeded() {
-        const nextDispatchProps = this.computeDispatchProps(this.store, this.props)
-        if (this.dispatchProps && shallowEqual(nextDispatchProps, this.dispatchProps)) {
-          return false
-        }
-
-        this.dispatchProps = nextDispatchProps
-        return true
-      }
-
-      updateMergedPropsIfNeeded() {
-        const nextMergedProps = computeMergedProps(this.stateProps, this.dispatchProps, this.props)
-        if (this.mergedProps && checkMergedEquals && shallowEqual(nextMergedProps, this.mergedProps)) {
-          return false
-        }
-
-        this.mergedProps = nextMergedProps
-        return true
-      }
-
-      isSubscribed() {
-        return typeof this.unsubscribe === 'function'
-      }
-
-      trySubscribe() {
-        if (shouldSubscribe && !this.unsubscribe) {
-          this.unsubscribe = this.store.subscribe(this.handleChange.bind(this))
-          this.handleChange()
-        }
-      }
-
-      tryUnsubscribe() {
-        if (this.unsubscribe) {
-          this.unsubscribe()
-          this.unsubscribe = null
-        }
-      }
-
-      componentDidMount() {
-        this.trySubscribe()
-      }
-
-      componentWillReceiveProps(nextProps) {
-        if (!pure || !shallowEqual(nextProps, this.props)) {
-          this.haveOwnPropsChanged = true
-        }
-      }
-
-      componentWillUnmount() {
-        this.tryUnsubscribe()
-        this.clearCache()
-      }
-
-      clearCache() {
-        this.dispatchProps = null
-        this.stateProps = null
-        this.mergedProps = null
-        this.haveOwnPropsChanged = true
-        this.hasStoreStateChanged = true
-        this.renderedElement = null
-        this.finalMapDispatchToProps = null
-        this.finalMapStateToProps = null
-      }
-
-      handleChange() {
-        if (!this.unsubscribe) {
-          return
-        }
-
-        const prevStoreState = this.state.storeState
-        const storeState = this.store.getState()
-
-        if (!pure || prevStoreState !== storeState) {
-          this.hasStoreStateChanged = true
-          this.setState({ storeState })
-        }
-      }
-
-      getWrappedInstance() {
-        invariant(withRef,
-          `To access the wrapped instance, you need to specify ` +
-          `{ withRef: true } as the fourth argument of the connect() call.`
-        )
-
-        return this.refs.wrappedInstance
-      }
-
-      render() {
-        const {
-          haveOwnPropsChanged,
-          hasStoreStateChanged,
-          renderedElement
-        } = this
-
-        this.haveOwnPropsChanged = false
-        this.hasStoreStateChanged = false
-
-        let shouldUpdateStateProps = true
-        let shouldUpdateDispatchProps = true
-        if (pure && renderedElement) {
-          shouldUpdateStateProps = hasStoreStateChanged || (
-            haveOwnPropsChanged && this.doStatePropsDependOnOwnProps
-          )
-          shouldUpdateDispatchProps =
-            haveOwnPropsChanged && this.doDispatchPropsDependOnOwnProps
-        }
-
-        let haveStatePropsChanged = false
-        let haveDispatchPropsChanged = false
-        if (shouldUpdateStateProps) {
-          haveStatePropsChanged = this.updateStatePropsIfNeeded()
-        }
-        if (shouldUpdateDispatchProps) {
-          haveDispatchPropsChanged = this.updateDispatchPropsIfNeeded()
-        }
-
-        let haveMergedPropsChanged = true
-        if (
-          haveStatePropsChanged ||
-          haveDispatchPropsChanged ||
-          haveOwnPropsChanged
-        ) {
-          haveMergedPropsChanged = this.updateMergedPropsIfNeeded()
-        } else {
-          haveMergedPropsChanged = false
-        }
-
-        if (!haveMergedPropsChanged && renderedElement) {
-          return renderedElement
-        }
-
-        if (withRef) {
-          this.renderedElement = createElement(WrappedComponent, {
-            ...this.mergedProps,
-            ref: 'wrappedInstance'
-          })
-        } else {
-          this.renderedElement = createElement(WrappedComponent,
-            this.mergedProps
-          )
-        }
-
-        return this.renderedElement
-      }
+    function computeMergedProps(stateProps, dispatchProps, parentProps) {
+      const mergedProps = finalMergeProps(stateProps, dispatchProps, parentProps)
+      invariant(
+        isPlainObject(mergedProps),
+        '`mergeProps` must return an object. Instead received %s.',
+        mergedProps
+      )
+      return mergedProps
     }
 
-    Connect.displayName = `Connect(${getDisplayName(WrappedComponent)})`
-    Connect.WrappedComponent = WrappedComponent
-    Connect.contextTypes = {
-      store: storeShape
-    }
-    Connect.propTypes = {
-      store: storeShape
-    }
+    return function wrapWithConnect(WrappedComponent) {
+      class InternalConnectClass extends ConnectComponentClass {
+        constructor(props, context) {
+          super(props, context)
 
-    if (process.env.NODE_ENV !== 'production') {
-      Connect.prototype.componentWillUpdate = function componentWillUpdate() {
-        if (this.version === version) {
-          return
+          this.pure = pure
+          this.version = version
+          this.withRef = withRef
+          this.mapState = mapState
+          this.mapDispatch = mapDispatch
+          this.shouldSubscribe = shouldSubscribe
+          this.computeMergedProps = computeMergedProps
+          this.checkMergedEquals = checkMergedEquals
         }
-
-        // We are hot reloading!
-        this.version = version
-        this.trySubscribe()
-        this.clearCache()
       }
-    }
 
-    return hoistStatics(Connect, WrappedComponent)
+      InternalConnectClass.displayName = `${getDisplayName(ConnectComponentClass)}(${getDisplayName(WrappedComponent)})`
+      InternalConnectClass.WrappedComponent = WrappedComponent
+      InternalConnectClass.contextTypes = {
+        store: storeShape
+      }
+      InternalConnectClass.propTypes = {
+        store: storeShape
+      }
+
+      if (process.env.NODE_ENV !== 'production') {
+        InternalConnectClass.prototype.componentWillUpdate = function componentWillUpdate() {
+          if (this.version === version) {
+            return
+          }
+
+          // We are hot reloading!
+          this.version = version
+          this.trySubscribe()
+          this.clearCache()
+        }
+      }
+
+      return hoistStatics(hoistStatics(InternalConnectClass, ConnectComponentClass), WrappedComponent)
+    }
   }
 }
+
+export class Connect extends Component {
+
+  shouldComponentUpdate() {
+    return !this.pure || this.haveOwnPropsChanged || this.hasStoreStateChanged
+  }
+
+  constructor(props, context) {
+    super(props, context)
+    this.store = props.store || context.store
+
+    invariant(this.store,
+      `Could not find "store" in either the context or ` +
+      `props of "${this.constructor.displayName}". ` +
+      `Either wrap the root component in a <Provider>, ` +
+      `or explicitly pass "store" as a prop to "${this.constructor.displayName}".`
+    )
+
+    const storeState = this.store.getState()
+    this.state = { storeState }
+    this.clearCache()
+  }
+
+  computeStateProps(store, props) {
+    if (!this.finalMapStateToProps) {
+      return this.configureFinalMapState(store, props)
+    }
+
+    const state = store.getState()
+    const stateProps = this.doStatePropsDependOnOwnProps ?
+      this.finalMapStateToProps(state, props) :
+      this.finalMapStateToProps(state)
+
+    return checkStateShape(stateProps)
+  }
+
+  configureFinalMapState(store, props) {
+    const mappedState = this.mapState(store.getState(), props)
+    const isFactory = typeof mappedState === 'function'
+
+    this.finalMapStateToProps = isFactory ? mappedState : this.mapState
+    this.doStatePropsDependOnOwnProps = this.finalMapStateToProps.length !== 1
+
+    return isFactory ?
+      this.computeStateProps(store, props) :
+      checkStateShape(mappedState)
+  }
+
+  computeDispatchProps(store, props) {
+    if (!this.finalMapDispatchToProps) {
+      return this.configureFinalMapDispatch(store, props)
+    }
+
+    const { dispatch } = store
+    const dispatchProps = this.doDispatchPropsDependOnOwnProps ?
+      this.finalMapDispatchToProps(dispatch, props) :
+      this.finalMapDispatchToProps(dispatch)
+
+    return checkStateShape(dispatchProps, true)
+  }
+
+  configureFinalMapDispatch(store, props) {
+    const mappedDispatch = this.mapDispatch(store.dispatch, props)
+    const isFactory = typeof mappedDispatch === 'function'
+
+    this.finalMapDispatchToProps = isFactory ? mappedDispatch : this.mapDispatch
+    this.doDispatchPropsDependOnOwnProps = this.finalMapDispatchToProps.length !== 1
+
+    return isFactory ?
+      this.computeDispatchProps(store, props) :
+      checkStateShape(mappedDispatch, true)
+  }
+
+  updateStatePropsIfNeeded() {
+    const nextStateProps = this.computeStateProps(this.store, this.props)
+    if (this.stateProps && shallowEqual(nextStateProps, this.stateProps)) {
+      return false
+    }
+
+    this.stateProps = nextStateProps
+    return true
+  }
+
+  updateDispatchPropsIfNeeded() {
+    const nextDispatchProps = this.computeDispatchProps(this.store, this.props)
+    if (this.dispatchProps && shallowEqual(nextDispatchProps, this.dispatchProps)) {
+      return false
+    }
+
+    this.dispatchProps = nextDispatchProps
+    return true
+  }
+
+  updateMergedPropsIfNeeded() {
+    const nextMergedProps = this.computeMergedProps(this.stateProps, this.dispatchProps, this.props)
+    if (this.mergedProps && this.checkMergedEquals && shallowEqual(nextMergedProps, this.mergedProps)) {
+      return false
+    }
+
+    this.mergedProps = nextMergedProps
+    return true
+  }
+
+  isSubscribed() {
+    return typeof this.unsubscribe === 'function'
+  }
+
+  trySubscribe() {
+    if (this.shouldSubscribe && !this.unsubscribe) {
+      this.unsubscribe = this.store.subscribe(this.handleChange.bind(this))
+      this.handleChange()
+    }
+  }
+
+  tryUnsubscribe() {
+    if (this.unsubscribe) {
+      this.unsubscribe()
+      this.unsubscribe = null
+    }
+  }
+
+  componentDidMount() {
+    this.trySubscribe()
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (!this.pure || !shallowEqual(nextProps, this.props)) {
+      this.haveOwnPropsChanged = true
+    }
+  }
+
+  componentWillUnmount() {
+    this.tryUnsubscribe()
+    this.clearCache()
+  }
+
+  clearCache() {
+    this.dispatchProps = null
+    this.stateProps = null
+    this.mergedProps = null
+    this.haveOwnPropsChanged = true
+    this.hasStoreStateChanged = true
+    this.renderedElement = null
+    this.finalMapDispatchToProps = null
+    this.finalMapStateToProps = null
+  }
+
+  handleChange() {
+    if (!this.unsubscribe) {
+      return
+    }
+
+    const prevStoreState = this.state.storeState
+    const storeState = this.store.getState()
+
+    if (!this.pure || prevStoreState !== storeState) {
+      this.hasStoreStateChanged = true
+      this.setState({ storeState })
+    }
+  }
+
+  getWrappedInstance() {
+    invariant(this.withRef,
+      `To access the wrapped instance, you need to specify ` +
+      `{ withRef: true } as the fourth argument of the connect() call.`
+    )
+
+    return this.refs.wrappedInstance
+  }
+
+  render() {
+    const {
+      haveOwnPropsChanged,
+      hasStoreStateChanged,
+      renderedElement
+    } = this
+
+    this.haveOwnPropsChanged = false
+    this.hasStoreStateChanged = false
+
+    let shouldUpdateStateProps = true
+    let shouldUpdateDispatchProps = true
+    if (this.pure && renderedElement) {
+      shouldUpdateStateProps = hasStoreStateChanged || (
+        haveOwnPropsChanged && this.doStatePropsDependOnOwnProps
+      )
+      shouldUpdateDispatchProps =
+        haveOwnPropsChanged && this.doDispatchPropsDependOnOwnProps
+    }
+
+    let haveStatePropsChanged = false
+    let haveDispatchPropsChanged = false
+    if (shouldUpdateStateProps) {
+      haveStatePropsChanged = this.updateStatePropsIfNeeded()
+    }
+    if (shouldUpdateDispatchProps) {
+      haveDispatchPropsChanged = this.updateDispatchPropsIfNeeded()
+    }
+
+    let haveMergedPropsChanged = true
+    if (
+      haveStatePropsChanged ||
+      haveDispatchPropsChanged ||
+      haveOwnPropsChanged
+    ) {
+      haveMergedPropsChanged = this.updateMergedPropsIfNeeded()
+    } else {
+      haveMergedPropsChanged = false
+    }
+
+    if (!haveMergedPropsChanged && renderedElement) {
+      return renderedElement
+    }
+
+    if (this.withRef) {
+      this.renderedElement = createElement(this.constructor.WrappedComponent, {
+        ...this.mergedProps,
+        ref: 'wrappedInstance'
+      })
+    } else {
+      this.renderedElement = createElement(this.constructor.WrappedComponent,
+        this.mergedProps
+      )
+    }
+
+    return this.renderedElement
+  }
+}
+
+export default createConnect(Connect)


### PR DESCRIPTION
I've attempted to refactor `connect` to provide additional (optional) exports that would allow the user to easily create a custom `Connect` class. This allows the user to override specific parts of `Connect` while maintaining all the existing caching and update logic. Here is an example of usage:

```javascript
import { Connect, createConnect } from 'react-redux/components/connect'

class MyConnect extends Connect {
  handleChange() {
    if (!this.unsubscribe) {
      return
    }

    const prevStoreState = this.state.storeState
    const storeState = this.store.getState()

    if (!this.pure || prevStoreState !== storeState) {
      this.hasStoreStateChanged = true
      return new Promise((resolve) => { this.setState({ storeState }, resolve) })
    }
  }
}

export default createConnect(MyConnect)
```

In this example I've overridden the `handleChange` method to return a Promise that resolves when the changes have been flushed to the DOM.

You then just use this custom `connect` method to decorate your components instead of the default one from react-redux.

All but one of the tests are passing, but I'm interested in getting feedback on this before working on it further.